### PR TITLE
fix(vscode settings): Setting to make endOfLine Consistent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.endOfLine": "lf",
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
Now endOfLine is Consistent 'LF' in all Operating System